### PR TITLE
hotfix: update homepage to v0.9.1

### DIFF
--- a/include.core.compose.yaml
+++ b/include.core.compose.yaml
@@ -6,7 +6,7 @@ services:
   homepage:
     container_name: teleporter-homepage
     hostname: teleporter-homepage
-    image: ghcr.io/gethomepage/homepage:v0.9.0
+    image: ghcr.io/gethomepage/homepage:v0.9.1
     command: ["sh", "-c", "/sbin/ip route add ${VPN_NETWORK} via ${VPN_LOCAL_IP} && node server.js"]
     restart: always
     environment:


### PR DESCRIPTION
Because v0.9.0 was deleted https://github.com/gethomepage/homepage/releases/tag/v0.9.1