### PR TITLE
fix: homepage broken if no vpn, new env system.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ config/vscode/
 node_modules
 # Private and secrets
 vpn.env*
+.env
+local.env
 # Code
 code/
 # Backup

--- a/compose.yaml
+++ b/compose.yaml
@@ -4,17 +4,20 @@ include:
     # Core: Contains services essential to basic operation
     - path: include.core.compose.yaml
       env_file:
-        - .env
+        - default.env
+        - local.env
 
     # App: Contains basic applications providing services
     - path: include.app.compose.yaml
       env_file:
-        - .env
+        - default.env
+        - local.env
 
     # Edu: Contains services that can be customised by the teaching team
     - path: include.edu.compose.yaml
       env_file:
-        - .env
+        - default.env
+        - local.env
 
 volumes:
   mariadb_data:

--- a/compose.yaml
+++ b/compose.yaml
@@ -5,19 +5,16 @@ include:
     - path: include.core.compose.yaml
       env_file:
         - .env
-        - vpn.env
 
     # App: Contains basic applications providing services
     - path: include.app.compose.yaml
       env_file:
         - .env
-        - vpn.env
 
     # Edu: Contains services that can be customised by the teaching team
     - path: include.edu.compose.yaml
       env_file:
         - .env
-        - vpn.env
 
 volumes:
   mariadb_data:

--- a/config/homepage/services_template.j2
+++ b/config/homepage/services_template.j2
@@ -10,10 +10,6 @@
         href: https://vpn.eddi.cloud
         ping: 10.0.0.1
         statusStyle: basic
-    - Accès VPN:
-        description: pour générer ma configuration VPN
-        icon: si-openvpn
-        href: https://vpn.eddi.cloud
     - File Browser:
         href: ./file-browser
         container: teleporter-filebrowser
@@ -102,7 +98,9 @@
         href: http://node3003.{{HOMEPAGE_VAR_VPN_NAME}}.localhost
         siteMonitor: http://10.200.0.202:3003
 {% endraw %}
+{% if clients %}
 - Ma promo:
+{% endif %}
 {% for client_name, client_ip in clients %}
     - Teleporter de {{ client_name  }}:
         description: Se connecter sur le téléporteur de {{ client_name }}

--- a/default.env
+++ b/default.env
@@ -32,8 +32,6 @@ VPN_NETWORK=10.0.0.0/22
 VPN_WILDCARD=22
 # Private IP address for VPN
 VPN_PRIV_IP=10.0.0.1
-# Default vpn_name if vpn is not setted
-VPN_NAME="myself"
 # List of extensions for vscode, separated by |  
 # Original teleporter list : https://github.com/O-clock-Dev/TeleporterV8/blob/master/ansible/roles/code-editor/files/vscode-extensions.sh
 VSCODE_EXTENSIONS_LIST=aaron-bond.better-comments|bierner.markdown-preview-github-styles|bmewburn.vscode-intelephense-client|dbaeumer.vscode-eslint|DavidAnson.vscode-markdownlint|dracula-theme.theme-dracula|EditorConfig.EditorConfig|file-icons.file-icons|MS-vsliveshare.vsliveshare|MS-CEINTL.vscode-language-pack-fr|ph-hawkins.arc-plus|stylelint.vscode-stylelint|wayou.vscode-todo-highlight|whatwedo.twig|yzhang.markdown-all-in-one

--- a/default.env
+++ b/default.env
@@ -1,3 +1,7 @@
+#
+# Don't touch this file, if you needed to update parameters, use local.env file.
+#
+
 # Autoheal container label for monitoring
 AUTOHEAL_CONTAINER_LABEL=all
 # Autoheal start period in seconds
@@ -17,6 +21,9 @@ BACKUP_DIR=./backup
 LANG=fr_FR.UTF-8
 # Timezone setting
 TZ=Europe/Paris
+
+# Name for the promo if not setted
+VPN_NAME=myself
 # Local IP address for VPN
 VPN_LOCAL_IP=10.200.0.254
 # Local port for VPN
@@ -25,6 +32,8 @@ VPN_NETWORK=10.0.0.0/22
 VPN_WILDCARD=22
 # Private IP address for VPN
 VPN_PRIV_IP=10.0.0.1
+# Default vpn_name if vpn is not setted
+VPN_NAME="myself"
 # List of extensions for vscode, separated by |  
 # Original teleporter list : https://github.com/O-clock-Dev/TeleporterV8/blob/master/ansible/roles/code-editor/files/vscode-extensions.sh
 VSCODE_EXTENSIONS_LIST=aaron-bond.better-comments|bierner.markdown-preview-github-styles|bmewburn.vscode-intelephense-client|dbaeumer.vscode-eslint|DavidAnson.vscode-markdownlint|dracula-theme.theme-dracula|EditorConfig.EditorConfig|file-icons.file-icons|MS-vsliveshare.vsliveshare|MS-CEINTL.vscode-language-pack-fr|ph-hawkins.arc-plus|stylelint.vscode-stylelint|wayou.vscode-todo-highlight|whatwedo.twig|yzhang.markdown-all-in-one

--- a/include.core.compose.yaml
+++ b/include.core.compose.yaml
@@ -1,5 +1,6 @@
 # Teleporter Core Containers
 
+
 services:
 
   # Dashboard
@@ -22,10 +23,6 @@ services:
         ipv4_address: 10.200.0.203
     cap_add:
       - NET_ADMIN
-    env_file:
-      - path: ./vpn.env
-        required: false
-
 
   # Reverse Proxy
   reverse_proxy:
@@ -89,9 +86,6 @@ services:
       # Should be switched to VPN_SERVER_PORT when issue#6 is done on vpn-compose project
       VPN_SERVER_PORT: ${VPN_LOCAL_PORT}
       VPN_WILDCARD: ${VPN_WILDCARD}
-    env_file:
-      - path: ./vpn.env
-        required: false
     ports:
       - "${VPN_LOCAL_PORT:-6666}:${VPN_LOCAL_PORT:-6666}/udp"
     volumes:
@@ -141,11 +135,8 @@ services:
     image: oclock/teleporter-templating-config:fe3814940bd30a0298adafad1dfd686bb4489002
     environment:
       IP_PRIV: ${IP_PRIV}
-      VPN_NAME: ${VPN_NAME:-myself}
-      PROMO: ${PROMO:-Sans promo}
-    env_file:
-      - path: ./vpn.env
-        required: false
+      VPN_NAME: ${VPN_NAME}
+      PROMO: ${PROMO}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ${CONFIG_DIR}/:/app/config/

--- a/include.core.compose.yaml
+++ b/include.core.compose.yaml
@@ -134,8 +134,8 @@ services:
     image: oclock/teleporter-templating-config:bc4294dd973754c2f48a2aadbfbdbd814c8493a9
     environment:
       IP_PRIV: ${IP_PRIV}
-      VPN_NAME: ${VPN_NAME}
-      PROMO: ${PROMO}
+      VPN_NAME: ${VPN_NAME:-myself}
+      PROMO: ${PROMO:-Sans promo}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ${CONFIG_DIR}/:/app/config/

--- a/include.core.compose.yaml
+++ b/include.core.compose.yaml
@@ -131,7 +131,7 @@ services:
   # Template Config
   templating-config:
     container_name: teleporter-templating-config
-    image: oclock/teleporter-templating-config:bc4294dd973754c2f48a2aadbfbdbd814c8493a9
+    image: oclock/teleporter-templating-config:fe3814940bd30a0298adafad1dfd686bb4489002
     environment:
       IP_PRIV: ${IP_PRIV}
       VPN_NAME: ${VPN_NAME:-myself}

--- a/include.core.compose.yaml
+++ b/include.core.compose.yaml
@@ -78,14 +78,14 @@ services:
     image: oclock/teleporter-vpn:dd7d23c5eea0cc4d01c658a82405123cb86a2ef6
     restart: always
     environment:
-      KEY_PRIV: ${KEY_PRIV}
-      KEY_VPN_SERVER: ${KEY_VPN_SERVER}
-      IP_PRIV: ${IP_PRIV}
-      VPN_SERVER: ${VPN_SERVER}
-      VPN_LOCAL_PORT: ${VPN_LOCAL_PORT}
+      KEY_PRIV: ${KEY_PRIV:-}
+      KEY_VPN_SERVER: ${KEY_VPN_SERVER:-}
+      IP_PRIV: ${IP_PRIV:-}
+      VPN_SERVER: ${VPN_SERVER:-}
+      VPN_LOCAL_PORT: ${VPN_LOCAL_PORT:-}
       # Should be switched to VPN_SERVER_PORT when issue#6 is done on vpn-compose project
-      VPN_SERVER_PORT: ${VPN_LOCAL_PORT}
-      VPN_WILDCARD: ${VPN_WILDCARD}
+      VPN_SERVER_PORT: ${VPN_LOCAL_PORT:-}
+      VPN_WILDCARD: ${VPN_WILDCARD:-}
     ports:
       - "${VPN_LOCAL_PORT:-6666}:${VPN_LOCAL_PORT:-6666}/udp"
     volumes:
@@ -134,9 +134,9 @@ services:
     container_name: teleporter-templating-config
     image: oclock/teleporter-templating-config:fe3814940bd30a0298adafad1dfd686bb4489002
     environment:
-      IP_PRIV: ${IP_PRIV}
+      IP_PRIV: ${IP_PRIV:-}
       VPN_NAME: ${VPN_NAME}
-      PROMO: ${PROMO}
+      PROMO: ${PROMO:-}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ${CONFIG_DIR}/:/app/config/

--- a/include.core.compose.yaml
+++ b/include.core.compose.yaml
@@ -10,7 +10,7 @@ services:
     command: ["sh", "-c", "/sbin/ip route add ${VPN_NETWORK} via ${VPN_LOCAL_IP} && node server.js"]
     restart: always
     environment:
-      HOMEPAGE_VAR_USER_NAME: "${FULL_NAME:-Téléporteur pas configuré !}"
+      HOMEPAGE_VAR_USER_NAME: "${FULL_NAME:- VPN non configuré !}"
       HOMEPAGE_VAR_COHORT: "${PROMO:-Sans promo}"
       HOMEPAGE_VAR_VPN_NAME: "${VPN_NAME:-myself}"
     volumes:
@@ -22,6 +22,10 @@ services:
         ipv4_address: 10.200.0.203
     cap_add:
       - NET_ADMIN
+    env_file:
+      - path: ./vpn.env
+        required: false
+
 
   # Reverse Proxy
   reverse_proxy:
@@ -85,8 +89,11 @@ services:
       # Should be switched to VPN_SERVER_PORT when issue#6 is done on vpn-compose project
       VPN_SERVER_PORT: ${VPN_LOCAL_PORT}
       VPN_WILDCARD: ${VPN_WILDCARD}
+    env_file:
+      - path: ./vpn.env
+        required: false
     ports:
-      - "${VPN_LOCAL_PORT}:${VPN_LOCAL_PORT}/udp"
+      - "${VPN_LOCAL_PORT:-6666}:${VPN_LOCAL_PORT:-6666}/udp"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     healthcheck:
@@ -136,6 +143,9 @@ services:
       IP_PRIV: ${IP_PRIV}
       VPN_NAME: ${VPN_NAME:-myself}
       PROMO: ${PROMO:-Sans promo}
+    env_file:
+      - path: ./vpn.env
+        required: false
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ${CONFIG_DIR}/:/app/config/

--- a/local.env
+++ b/local.env
@@ -1,0 +1,30 @@
+#
+# Here some paraemeters you can change
+#
+
+## Permissions should be taken care of using various workarounds to make sure the user can always change the content of this folder on the host.
+#CODE_DIR=./code
+## Data folder that contains things like config files or database files that the user won't manipulate directly. 
+## Permissions might be funky since there might be files coming from inside the container
+## 2024-05-30: Deprecation notice as we prefer to use Docker volumes
+#DATA_DIR=./data
+## Configurations
+#CONFIG_DIR=./config
+## Backups
+#BACKUP_DIR=./backup
+## Language variable
+#LANG=fr_FR.UTF-8
+## Timezone setting
+#TZ=Europe/Paris
+#VSCODE_EXTENSIONS_LIST=aaron-bond.better-comments|bierner.markdown-preview-github-styles|bmewburn.vscode-intelephense-client|dbaeumer.vscode-eslint|DavidAnson.vscode-markdownlint|dracula-theme.theme-dracula|EditorConfig.EditorConfig|file-icons.file-icons|MS-vsliveshare.vsliveshare|MS-CEINTL.vscode-language-pack-fr|ph-hawkins.arc-plus|stylelint.vscode-stylelint|wayou.vscode-todo-highlight|whatwedo.twig|yzhang.markdown-all-in-one
+## Directory for web-related files
+#WEB_DIR=www
+## Public directory within the web directory
+#WEB_PUBLIC_DIR=./www/public
+## MariaDB root password
+#MARIADB_ROOT_PASSWORD=root
+## PGSQL
+#POSTGRES_PASSWORD=js4life
+## MongoDB
+#MONGO_INITDB_ROOT_USERNAME=root
+#MONGO_INITDB_ROOT_PASSWORD=root


### PR DESCRIPTION
New env logic :

* delete vpn.env, we will use now .env to store secrets
* default.env contains all settings, do not update it directly
* local.env the good place to update settings if needed

Template generation handle now non existent vpn settings, and empty promo teammates.

With these fixes, VPN should start directly without any configuration or VPN settings.